### PR TITLE
Adds :data_type option to EventbriteClient

### DIFF
--- a/lib/eventbrite-client.rb
+++ b/lib/eventbrite-client.rb
@@ -5,7 +5,7 @@ class EventbriteClient
 
   def initialize( auth_tokens )
     @auth = {}
-    @data_type = 'json'
+    @data_type = (auth_tokens.is_a?(Hash) and auth_tokens.include? :data_type) ? auth_tokens[:data_type] : 'json'
     if auth_tokens.is_a? Hash
       if auth_tokens.include? :access_token
         # use oauth2 authentication tokens


### PR DESCRIPTION
In some cases I need to be able to get the XML body of the response (I need to store those for further XPath processing), therefore I needed to add an option to specify `data_type` manually. By default it will use `json` so it doesn't change default behaviour.
